### PR TITLE
Fix 'Ract developer' typo globally

### DIFF
--- a/docs/accessing-a-child-component.md
+++ b/docs/accessing-a-child-component.md
@@ -2,7 +2,7 @@
 id: accessing-a-child-component
 sidebar_label: Accessing a child component
 title: Accessing a Child Component
-description: Accessing a child component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Accessing a child component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['accessing a child component', 'accessingachildcomponent', 'statelessfunction', 'presentational component', 'presentationalcomponent', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Accessing a child component
 image: /img/reactpatterns-cover.png

--- a/docs/component-injection.md
+++ b/docs/component-injection.md
@@ -2,7 +2,7 @@
 id: component-injection
 sidebar_label: Component injection
 title: Component Injection
-description: Component injection | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Component injection | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['component injection', 'react component injection', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Component injection
 image: /img/reactpatterns-cover.png

--- a/docs/conditional-rendering-with-enum.md
+++ b/docs/conditional-rendering-with-enum.md
@@ -2,7 +2,7 @@
 id: conditional-rendering-with-enum
 sidebar_label: Conditional rendering with enum
 title: Conditional Rendering with Enum
-description: Conditional rendering with enum | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Conditional rendering with enum | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['conditional rendering with enum', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Conditional rendering with enum
 image: /img/reactpatterns-cover.png

--- a/docs/container-component.md
+++ b/docs/container-component.md
@@ -2,7 +2,7 @@
 id: container-component
 sidebar_label: Container component (Stateful component)
 title: Container Component (Stateful Component)
-description: Container component (Stateful component) | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Container component (Stateful component) | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['container component (stateful component)', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Container component (Stateful component)
 image: /img/reactpatterns-cover.png

--- a/docs/destructuring-function-argument.md
+++ b/docs/destructuring-function-argument.md
@@ -2,7 +2,7 @@
 id: destructuring-function-argument
 sidebar_label: Destructuring function argument
 title: Destructuring Function Argument
-description: Destructuring function argument | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Destructuring function argument | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['destructuring function argument', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Destructuring function argument
 image: /img/reactpatterns-cover.png

--- a/docs/destructuring-rest-or-spread-operator.md
+++ b/docs/destructuring-rest-or-spread-operator.md
@@ -2,7 +2,7 @@
 id: destructuring-rest-or-spread-operator
 sidebar_label: Destructuring rest/spread operator
 title: Destructuring Rest/Spread Operator
-description: Destructuring rest/spread operator | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Destructuring rest/spread operator | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['destructuring rest/spread operator', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Destructuring rest/spread operator
 image: /img/reactpatterns-cover.png

--- a/docs/destructuring.md
+++ b/docs/destructuring.md
@@ -2,7 +2,7 @@
 id: destructuring
 sidebar_label: What is destructuring?
 title: What is Destructuring?
-description: Destructuring | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Destructuring | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['destructuring', 'react component injection', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Destructuring
 image: /img/reactpatterns-cover.png

--- a/docs/external-templating-component.md
+++ b/docs/external-templating-component.md
@@ -2,7 +2,7 @@
 id: external-templating-component
 sidebar_label: External templating component
 title: External Templating Component
-description: External templating component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: External templating component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['external templating component', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: External templating component
 image: /img/reactpatterns-cover.png

--- a/docs/function-as-child-component.md
+++ b/docs/function-as-child-component.md
@@ -2,7 +2,7 @@
 id: function-as-child-component
 sidebar_label: Function as child component
 title: Function as Child Component
-description: Function as child component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Function as child component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['function as child component', 'child component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Function as child component
 image: /img/reactpatterns-cover.png

--- a/docs/function-as-prop-component.md
+++ b/docs/function-as-prop-component.md
@@ -2,7 +2,7 @@
 id: function-as-prop-component
 sidebar_label: Function as prop component
 title: Function as Prop Component
-description: Function as prop component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Function as prop component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['function as prop component', 'function as prop', 'prop component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Function as prop component
 image: /img/reactpatterns-cover.png

--- a/docs/higher-order-component.md
+++ b/docs/higher-order-component.md
@@ -2,7 +2,7 @@
 id: higher-order-component
 sidebar_label: Higher-Order component
 title: Higher-Order Component
-description: Higher-Order component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Higher-Order component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['higher-order component', 'higher order component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Higher-Order components
 image: /img/reactpatterns-cover.png

--- a/docs/higher-order-function.md
+++ b/docs/higher-order-function.md
@@ -2,7 +2,7 @@
 id: higher-order-function
 sidebar_label: Higher-Order function
 title: Higher-Order Function
-description: Higher-Order function | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Higher-Order function | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['higher-order function', 'higher order function', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Higher-Order functions
 image: /img/reactpatterns-cover.png

--- a/docs/home.md
+++ b/docs/home.md
@@ -2,13 +2,13 @@
 id: home
 title: React Patterns
 sidebar_label: Introduction
-description: React Patterns, techniques, tips and tricks in development for Ract developer.
+description: React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Introduction
 image: /img/reactpatterns-cover.png
 slug: /
 ---
 
-React Patterns, techniques, tips and tricks in development for Ract developer.
+React Patterns, techniques, tips and tricks in development for React developers.
 
 To get the latest React patterns docs and blogs follow us on <a href="https://twitter.com/reactjspatterns">Twitter</a>, <a href="https://github.com/reactpatterns/reactpatterns">Github</a>, and <a href="https://www.facebook.com/ReactJSPatterns">Facebook</a>.

--- a/docs/if-else.md
+++ b/docs/if-else.md
@@ -2,7 +2,7 @@
 id: if-else
 sidebar_label: If else
 title: If Else
-description: If else | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: If else | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['if else', 'react conditional rendering', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: If else
 image: /img/reactpatterns-cover.png

--- a/docs/indexes-as-a-key-is-an-anti-pattern.md
+++ b/docs/indexes-as-a-key-is-an-anti-pattern.md
@@ -2,7 +2,7 @@
 id: indexes-as-a-key-is-an-anti-pattern
 sidebar_label: Indexes as a key is an anti-pattern
 title: Indexes as a Key is an Anti-pattern
-description: Indexes as a key is an anti-pattern | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Indexes as a key is an anti-pattern | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['indexes as a key is an anti-pattern', 'higher order function', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Indexes as a key is an anti-pattern
 image: /img/reactpatterns-cover.png

--- a/docs/jsx-spread-attributes.md
+++ b/docs/jsx-spread-attributes.md
@@ -2,7 +2,7 @@
 id: jsx-spread-attributes
 sidebar_label: JSX spread attributes
 title: JSX Spread Attributes
-description: JSX spread attributes | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: JSX spread attributes | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['jsx spread attributes', 'jsx attributes', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: JSX spread attributes
 image: /img/reactpatterns-cover.png

--- a/docs/logical-and-operator.md
+++ b/docs/logical-and-operator.md
@@ -2,7 +2,7 @@
 id: logical-and-operator
 sidebar_label: Logical && operator
 title: Logical && Operator
-description: Logical && operator | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Logical && operator | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['logical && operator', 'react logical && operator', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Logical && operator
 image: /img/reactpatterns-cover.png

--- a/docs/make-the-api-call-in-componentdidmount.md
+++ b/docs/make-the-api-call-in-componentdidmount.md
@@ -2,7 +2,7 @@
 id: make-the-api-call-in-componentdidmount
 sidebar_label: Make the API call
 title: Make the API Call in componentDidMount()
-description: Make the API call in componentDidMount(), techniques, tips and tricks in development for Ract developer.
+description: Make the API call in componentDidMount(), techniques, tips and tricks in development for React developers.
 keywords: ['make the api call in componentDidMount()', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Make the API call in componentDidMount()
 image: /img/reactpatterns-cover.png

--- a/docs/multi-level-conditional-rendering.md
+++ b/docs/multi-level-conditional-rendering.md
@@ -2,7 +2,7 @@
 id: multi-level-conditional-rendering
 sidebar_label: Multi-level conditional rendering
 title: Multi-level Conditional Rendering
-description: Multi-level conditional rendering, techniques, tips and tricks in development for Ract developer.
+description: Multi-level conditional rendering, techniques, tips and tricks in development for React developers.
 keywords: ['multi-level conditional rendering', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Multi-level conditional rendering
 image: /img/reactpatterns-cover.png

--- a/docs/nested-destructuring.md
+++ b/docs/nested-destructuring.md
@@ -2,7 +2,7 @@
 id: nested-destructuring
 sidebar_label: Nested destructuring
 title: Nested Destructuring
-description: Nested destructuring | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Nested destructuring | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['nested destructuring', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Nested destructuring
 image: /img/reactpatterns-cover.png

--- a/docs/promises-over-callbacks.md
+++ b/docs/promises-over-callbacks.md
@@ -2,7 +2,7 @@
 id: promises-over-callbacks
 sidebar_label: Promises over callbacks
 title: Promises over callbacks
-description: Promises over callbacks | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Promises over callbacks | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['promises over callbacks', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Promises over callbacks
 image: /img/reactpatterns-cover.png

--- a/docs/props-in-initial-state-is-an-anti-pattern.md
+++ b/docs/props-in-initial-state-is-an-anti-pattern.md
@@ -2,7 +2,7 @@
 id: props-in-initial-state-is-an-anti-pattern
 sidebar_label: Props in initial state is an anti-pattern
 title: Props in Initial State is an Anti-pattern
-description: Props in initial state is an anti-pattern | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Props in initial state is an anti-pattern | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['props in initial state is an anti-pattern', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Props in initial state is an anti-pattern
 image: /img/reactpatterns-cover.png

--- a/docs/proxy-component.md
+++ b/docs/proxy-component.md
@@ -2,7 +2,7 @@
 id: proxy-component
 sidebar_label: Proxy component
 title: Proxy Component
-description: Proxy Component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Proxy Component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['proxy component', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Proxy Component
 image: /img/reactpatterns-cover.png

--- a/docs/pure-component-avoid-heavy-re-render.md
+++ b/docs/pure-component-avoid-heavy-re-render.md
@@ -2,7 +2,7 @@
 id: pure-component-avoid-heavy-re-render
 sidebar_label: Pure component avoid heavy re-render
 title: Pure Component Avoid Heavy Re-render
-description: Pure component avoid heavy re-render | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Pure component avoid heavy re-render | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['pure component avoid heavy re-render', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Pure component avoid heavy re-render
 image: /img/reactpatterns-cover.png

--- a/docs/render-callback.md
+++ b/docs/render-callback.md
@@ -2,7 +2,7 @@
 id: render-callback
 sidebar_label: Render callback
 title: Render Callback
-description: Render callback | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Render callback | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['render callback', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Render callback
 image: /img/reactpatterns-cover.png

--- a/docs/shouldcomponentupdate-avoid-heavy-rerender.md
+++ b/docs/shouldcomponentupdate-avoid-heavy-rerender.md
@@ -2,7 +2,7 @@
 id: shouldcomponentupdate-avoid-heavy-re-render
 sidebar_label: shouldComponentUpdate avoid heavy re-renders
 title: shouldComponentUpdate Avoid Heavy Re-render
-description: shouldComponentUpdate avoid heavy re-renders | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: shouldComponentUpdate avoid heavy re-renders | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['shouldComponentUpdate avoid heavy re-renders', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: shouldComponentUpdate avoid heavy re-renders
 image: /img/reactpatterns-cover.png

--- a/docs/spreading-props-on-dom-elements-is-an-anti-pattern.md
+++ b/docs/spreading-props-on-dom-elements-is-an-anti-pattern.md
@@ -2,7 +2,7 @@
 id: spreading-props-on-dom-elements-is-an-anti-pattern
 sidebar_label: Spreading props on DOM elements is an anti-pattern
 title: Spreading props on DOM Elements is an Anti-pattern
-description: spreading props on DOM elements is an anti-pattern | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: spreading props on DOM elements is an anti-pattern | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['shouldComponentUpdate avoid heavy re-renders', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Spreading props on DOM elements is an anti-pattern
 image: /img/reactpatterns-cover.png

--- a/docs/state-hoisting.md
+++ b/docs/state-hoisting.md
@@ -2,7 +2,7 @@
 id: state-hoisting
 sidebar_label: State hoisting
 title: State Hoisting
-description: State hoisting | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: State hoisting | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['state hoisting', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: State hoisting
 image: /img/reactpatterns-cover.png

--- a/docs/stateless-function.md
+++ b/docs/stateless-function.md
@@ -2,7 +2,7 @@
 id: stateless-function
 sidebar_label: Stateless function
 title: Stateless Function (Presentational Component)
-description: Stateless function (Presentational component) | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Stateless function (Presentational component) | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['Stateless function', 'statelessfunction', 'presentational component', 'presentationalcomponent', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Stateless function (Presentational component)
 image: /img/reactpatterns-cover.png

--- a/docs/switch-case-operator.md
+++ b/docs/switch-case-operator.md
@@ -2,7 +2,7 @@
 id: switch-case-operator
 sidebar_label: Switch case operator
 title: Switch Case Operator
-description: Switch case operator | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Switch case operator | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['switch case operator', 'react switch case operator', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Switch case operator
 image: /img/reactpatterns-cover.png

--- a/docs/ternary-operation.md
+++ b/docs/ternary-operation.md
@@ -2,7 +2,7 @@
 id: ternary-operation
 sidebar_label: Ternary operation
 title: Ternary Operation
-description: Ternary operation | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: Ternary operation | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['ternary operation', 'react ternary operation', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: Ternary operation
 image: /img/reactpatterns-cover.png

--- a/docs/with-higher-order-component.md
+++ b/docs/with-higher-order-component.md
@@ -2,7 +2,7 @@
 id: with-higher-order-component
 sidebar_label: With higher order component
 title: With Higher Order Component
-description: With higher order component | React Patterns, techniques, tips and tricks in development for Ract developer.
+description: With higher order component | React Patterns, techniques, tips and tricks in development for React developers.
 keywords: ['with higher order component', 'react ternary operation', 'reactpatterns', 'react patterns', 'reactjspatterns', 'reactjs patterns', 'react', 'reactjs', 'react techniques', 'react tips and tricks']
 version: With higher order component
 image: /img/reactpatterns-cover.png

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   title: 'reactpatterns',
-  tagline: 'React Patterns, techniques, tips and tricks in development for Ract developer.',
+  tagline:
+    'React Patterns, techniques, tips and tricks in development for React developers.',
   url: 'https://reactpatterns.js.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -33,7 +34,7 @@ module.exports = {
           label: 'Home',
           position: 'right',
         },
-        {to: 'blog', label: 'Blog', position: 'right'},
+        { to: 'blog', label: 'Blog', position: 'right' },
         {
           href: 'https://github.com/reactpatterns',
           label: 'GitHub',
@@ -109,4 +110,4 @@ module.exports = {
       },
     ],
   ],
-};
+}


### PR DESCRIPTION
# Details

The homepage and meta descriptions all have a typo - "Ract developer", which should be "React developer".

# Issues

#4 